### PR TITLE
Rebuilt grunt task

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ Control is currently keyboard-only.
 
 ..for validating javascript
 ```
-$ grunt validate-js
+$ grunt jshint
 ```
-..for compiling files
+..for compiling files to dev folder
 ```
 $ grunt build
 ```
-..for development with watching (Sass, copy to dev folder, Server on 127.0.0.1:9000 with LiveReload)
+..for development with watching (build to dev folder, Server on 127.0.0.1:9000 with LiveReload)
 ```
 $ grunt
 ```
@@ -55,7 +55,7 @@ $ grunt publish
 ```
 ..for dist directory preview (server on 127.0.0.1:9001)
 ```
-$ grunt server-dist
+$ grunt preview-dist
 ```
 
 ### Created by

--- a/app/index.html
+++ b/app/index.html
@@ -23,12 +23,10 @@
 
       <div id="content"></div>
 
-      <!-- build:js js/vendor/thirdparty.min.js -->
       <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
       <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/rivets/0.8.1/rivets.bundled.min.js"></script>
-      <!-- endbuild -->
 
       <!-- build:js js/app.min.js -->
       <script src="js/module.js"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -9,7 +9,7 @@
       <link rel="shortcut icon" href="images/favicon-128.ico" />
       <link rel="apple-touch-icon-precomposed" href="images/favicon-152.png" />
 
-      <!-- build:css css/app.min.css -->
+      <!-- build:css(.tmp) css/app.min.css -->
       <link rel="stylesheet" href="css/app.css">
       <!-- endbuild -->
 

--- a/app/index.html
+++ b/app/index.html
@@ -24,7 +24,7 @@
       <div id="content"></div>
 
       <!-- build:js js/vendor/thirdparty.min.js -->
-      <script src="//cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
       <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/rivets/0.8.1/rivets.bundled.min.js"></script>
@@ -66,6 +66,6 @@
          alt="site stats"></a></div>
       </noscript>
       <!-- End of StatCounter Code for Default Guide -->
-      
+
    </body>
 </html>

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -1,7 +1,6 @@
 module.require(['Controller', 'fetcher'], function(Controller, fetcher) {
    'use strict';
-   var doc = $(document),
-       controller;
+   var controller;
 
    // Boot up application
    controller = new Controller(fetcher);

--- a/app/js/controller.js
+++ b/app/js/controller.js
@@ -144,8 +144,8 @@ module.require(['template', 'parser-verselink'], function(template, VerseLinkPar
       //    c.state.chapter = 1;
       //    c.state.book--;
       // } else {
-         c.state.chapter--;
-      
+      c.state.chapter--;
+
 
       c.controller.changeChapter(e, c);
    };
@@ -171,7 +171,7 @@ module.require(['template', 'parser-verselink'], function(template, VerseLinkPar
          state: {
             isLoading: true,
             isExpanding: true,
-            isFirstChapter: false,            
+            isFirstChapter: false,
             isLastChapter: false,
             edition: '',
             book: 1,

--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
     "grunt-contrib-jshint": "~0.8.0",
     "grunt-contrib-connect": "~0.10.1",
     "grunt-usemin": "~2.0.2",
-    "grunt-sass": "~1.0.0",
-    "underscore": "~1.8.3",
-    "rivets": "~0.8.1",
-    "modernizr": "~3.0.0-alpha.4"
+    "grunt-sass": "~1.0.0"
   }
 }


### PR DESCRIPTION
This adds path management, leaves the third party js on the CDNs, and gets `grunt publish` working again.

If making vendor/thirdparty.js is needed, it would be best to move to `npm` for managing those libs.